### PR TITLE
Fix error: 'async_generator' object is not iterable

### DIFF
--- a/mockfirestore/async_query.py
+++ b/mockfirestore/async_query.py
@@ -1,11 +1,11 @@
-from typing import AsyncIterator, List
+from typing import List, AsyncGenerator
 from mockfirestore.document import DocumentSnapshot
 from mockfirestore.query import Query
 from mockfirestore._helpers import consume_async_iterable
 
 
 class AsyncQuery(Query):
-    async def stream(self, transaction=None) -> AsyncIterator[DocumentSnapshot]:
+    async def stream(self, transaction=None) -> AsyncGenerator[DocumentSnapshot]:
         doc_snapshots = await consume_async_iterable(self.parent.stream())
         doc_snapshots = super()._process_field_filters(doc_snapshots)
         doc_snapshots = super()._process_pagination(doc_snapshots)
@@ -13,4 +13,4 @@ class AsyncQuery(Query):
             yield doc_snapshot
 
     async def get(self, transaction=None) -> List[DocumentSnapshot]:
-        return super().get()
+        return [result async for result in self.stream()]

--- a/mockfirestore/async_query.py
+++ b/mockfirestore/async_query.py
@@ -1,4 +1,4 @@
-from typing import List, AsyncGenerator, AsyncIterator
+from typing import List, AsyncIterator
 from mockfirestore.document import DocumentSnapshot
 from mockfirestore.query import Query
 from mockfirestore._helpers import consume_async_iterable

--- a/mockfirestore/async_query.py
+++ b/mockfirestore/async_query.py
@@ -1,11 +1,11 @@
-from typing import List, AsyncGenerator
+from typing import List, AsyncGenerator, AsyncIterator
 from mockfirestore.document import DocumentSnapshot
 from mockfirestore.query import Query
 from mockfirestore._helpers import consume_async_iterable
 
 
 class AsyncQuery(Query):
-    async def stream(self, transaction=None) -> AsyncGenerator[DocumentSnapshot]:
+    async def stream(self, transaction=None) -> AsyncIterator[DocumentSnapshot]:
         doc_snapshots = await consume_async_iterable(self.parent.stream())
         doc_snapshots = super()._process_field_filters(doc_snapshots)
         doc_snapshots = super()._process_pagination(doc_snapshots)
@@ -13,4 +13,4 @@ class AsyncQuery(Query):
             yield doc_snapshot
 
     async def get(self, transaction=None) -> List[DocumentSnapshot]:
-        return [result async for result in self.stream()]
+        return await consume_async_iterable(self.stream())

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1,0 +1,13 @@
+import aiounittest
+
+from mockfirestore import AsyncMockFirestore
+
+
+class TestAsyncMockFirestore(aiounittest.AsyncTestCase):
+    async def test_query_get(self):
+        fs = AsyncMockFirestore()
+        doc_in_fs = {"id": 1}
+        fs._data = {"foo": {"first": doc_in_fs}}
+        docs = await fs.collection("foo").where("id", "==", 1).get()
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].to_dict()["id"], 1)


### PR DESCRIPTION
Hi Anna,

Thank you for the awesome async support for python-mock-firestore! Today I was trying to use it and encountered the following error when running firestore query with a 'where' clause:

TypeError: 'async_generator' object is not iterable

After reading up on some material on async iterators and generators (see [here](https://bbc.github.io/cloudfit-public-docs/asyncio/asyncio-part-3.html)), it turns out the error was caused by a small bug in the code.  For the async `stream()` methods tend to return asynchronous generator objects, rather than iterators. Given that the list constructor used in `Query.get()` relies on synchronous iterators, the current code fails with the above error. Replacing this with the `AsyncQuery.stream()` method, and the `consume_async_iterable()` helper fix the above error. 

I have also added a test that reveals the error in the old code, and shows that the new code fixes the error.

It would be great if this could be reviewed and merged...